### PR TITLE
Fix LuaTables' internal redundant data going out of sync when deleting entries in a specific layout

### DIFF
--- a/luaj-core/src/main/java/org/luaj/vm2/LuaTable.java
+++ b/luaj-core/src/main/java/org/luaj/vm2/LuaTable.java
@@ -1470,7 +1470,7 @@ public class LuaTable extends LuaValue implements Metatable {
 				next = next.remove(target);
 				return this;
 			} else {
-				return next;
+				return next.remove(target);
 			}
 		}
 


### PR DESCRIPTION
Currently there is an edge case in the internals of LuaTable such that removing an entry when the hash buckets are in a specific layout, it causes no entry to be removed but the redundant `hashEntries` is still decremented, causing a desync between the redundant `hashEntries` and the actual number of entries in the hash buckets

The layout is specified by having a DeadSlot (whose associated object has been GC'd) pointing to any other slot

the purpose of DeadSlots is to provide better reliability for `pairs` when removing entries while iterating since when an entry is removed it's actually replaced by a DeadSlot containing a weak reference of the key

when this slot is asked to remove a specified slot, it checks if it's associated object has been GC'd, and if it did it removes itself from the hash buckets by returning the slot it's pointing at, without ever asking that slot from removing the specified slot even if it happened to contain it (DeadSlot does not represent an actual entry so no entry has been removed)

This leads to very inconsistent behaviour where iterating the table returns the entry it was supposed to remove, but indexing it returns nil since it's early-bailed by `hashEntries` being 0, and modifying the entry does not make it no longer return nil when indexed